### PR TITLE
breadthFirstSearch takes an optional maxDepth parameter

### DIFF
--- a/src/digraph-bfs.js
+++ b/src/digraph-bfs.js
@@ -44,7 +44,7 @@
         return bfsContext;
     };
 
-    module.exports.breadthFirstSearch = function(digraph_, searchContext_, startVertexId_, visitorInterface_, signalStartVertex_) {
+    module.exports.breadthFirstSearch = function(digraph_, searchContext_, startVertexId_, visitorInterface_, signalStartVertex_, maxDepth) {
 
         if ((digraph_ === null) || !digraph_ ||
             (searchContext_ === null) || !searchContext_ ||
@@ -89,7 +89,6 @@
         };
 
         if (initializeAsVisit) {
-
             enqueueRootVertex(startVertexId_);
 
         } else {
@@ -101,9 +100,23 @@
 
         }
 
+        var currentDepth = 0,
+            elementsToDepthIncrease = 1,
+            pendingDepthIncrease = true;
+
         while (searchQueue.length) {
+            if(elementsToDepthIncrease === 0) {
+                if(maxDepth && ++currentDepth > maxDepth) {
+                    return;
+                }
+
+                pendingDepthIncrease = true;
+            } else {
+                elementsToDepthIncrease--;
+            }
 
             var vertexId = searchQueue.shift();
+
             searchContext_.colorMap[vertexId] = colors.black;
 
             // examineVertex visitor callback.
@@ -112,6 +125,11 @@
             }
 
             var outEdges = digraph_.outEdges(vertexId);
+
+            if(pendingDepthIncrease) {
+                elementsToDepthIncrease = searchQueue.length;
+                pendingDepthIncrease = false;
+            }
 
             for (var index in outEdges) {
 


### PR DESCRIPTION
A common need is the ability to early out when performing a breadthFirstSearch when the search has reached a desired max level of depth.

Due to the manner in which the breadthFirstSearch method is implemented, there is some tracking that needs to live within the method itself.  I was not able to accomplish this early out functionality through an interface definition that the breadthFirstSearch method consumes.

I find this functionality to be convenient in my use of the library and wanted to offer it in case you feel it makes sense to pull in.