### PR TITLE
Add directedGraph to module exports for extensibility

### DIFF
--- a/src/arc_core_graph.js
+++ b/src/arc_core_graph.js
@@ -53,6 +53,8 @@ var jsgraph = module.exports = {
         ////
         create: require('./arc_core_digraph').createDirectedGraph,
 
+        directedGraph: require('./arc_core_digraph').DirectedGraph,
+
         // Directed graph transposition algorithm.
         // Creates a new DirectedGraph container object that's identical
         // to a caller-specified digraph except that the direction of the


### PR DESCRIPTION
directedGraph is not part part of the module exports which makes it impossible to modify the prototype in any way. 

To avoid doing a very extensive Encapsulation of the entire library to add a piece of functionality lets expose the prototype. That will allow other developers to add functionality like `getGetEdgesForVerticeWithProperty`

```
directedGraph.prototype.getGetEdgesForVerticeWithProperty = function(v, p) {
  const outEdges = this.outEdges(v);
  return _.filter(edges, (possibleEdge) => this.getEdgeProperty(possibleEdge) === p);
 }
```